### PR TITLE
Issue #8 Add way to launch editor even if no text file

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/companiontext/CompanionFileExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/companiontext/CompanionFileExtension.java
@@ -1,14 +1,20 @@
 package ca.corbett.imageviewer.extensions.companiontext;
 
 import ca.corbett.extensions.AppExtensionInfo;
+import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.RedispatchingMouseAdapter;
 import ca.corbett.extras.image.ImageUtil;
+import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.extras.properties.AbstractProperty;
 import ca.corbett.extras.properties.IntegerProperty;
+import ca.corbett.extras.properties.KeyStrokeProperty;
 import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.extensions.ImageViewerExtension;
+import ca.corbett.imageviewer.extensions.companiontext.actions.ShowCurrentAction;
 import ca.corbett.imageviewer.extensions.companiontext.actions.ShowTextFileAction;
+import ca.corbett.imageviewer.ui.MainWindow;
+import ca.corbett.imageviewer.ui.ReservedKeyStrokeWorkaround;
 import ca.corbett.imageviewer.ui.ThumbPanel;
 import org.apache.commons.io.FilenameUtils;
 
@@ -70,12 +76,14 @@ public class CompanionFileExtension extends ImageViewerExtension {
     private static final String fontSizePropName = "Thumbnails.Companion files.linkFontSize";
 
     private final AppExtensionInfo extInfo;
+    private final ShowCurrentAction showEditorForCurrentImage;
 
     public CompanionFileExtension() {
         extInfo = AppExtensionInfo.fromExtensionJar(getClass(), EXT_INFO);
         if (extInfo == null) {
             throw new RuntimeException("CompanionFileExtension: can't parse extInfo.json!");
         }
+        showEditorForCurrentImage = new ShowCurrentAction("Companion text file...");
     }
 
     @Override
@@ -96,7 +104,29 @@ public class CompanionFileExtension extends ImageViewerExtension {
     protected List<AbstractProperty> createConfigProperties() {
         List<AbstractProperty> list = new ArrayList<>();
         list.add(new IntegerProperty(fontSizePropName, "Hyperlink font size", 10, 8, 16, 1));
+        list.add(new KeyStrokeProperty(AppConfig.KEYSTROKE_PREFIX + "Companion text file.showEditor",
+                                       "Text editor:",
+                                       KeyStrokeManager.parseKeyStroke("Ctrl+T"),
+                                       showEditorForCurrentImage)
+                     .setAllowBlank(true)
+                     .setHelpText("<html>Shows the companion text file for the selected image.<br>"
+                                      + "Will create a new empty text file if none exists.</html>")
+                     .addFormFieldGenerationListener(new ReservedKeyStrokeWorkaround()));
         return list;
+    }
+
+    /**
+     * Overridden so we can add a menu item to the Edit menu for launching the text editor
+     * for the currently selected image.
+     */
+    @Override
+    public List<EnhancedAction> getMenuActions(String topLevelMenu, MainWindow.BrowseMode browseMode) {
+        // Note: we don't care about browseMode here, we always want to add our action to the Edit menu.
+        List<EnhancedAction> actions = new ArrayList<>();
+        if ("Edit".equals(topLevelMenu)) {
+            actions.add(showEditorForCurrentImage);
+        }
+        return actions;
     }
 
     /**

--- a/src/main/java/ca/corbett/imageviewer/extensions/companiontext/actions/ShowCurrentAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/companiontext/actions/ShowCurrentAction.java
@@ -32,10 +32,10 @@ public class ShowCurrentAction extends EnhancedAction {
         // Figure out where the companion text file should live:
         // (it's no problem if it's not there, our ShowTextFileAction will handle that)
         File imageFile = currentImage.getImageFile();
-        File testFile = new File(imageFile.getParentFile(), FilenameUtils.getBaseName(imageFile.getName()) + ".txt");
+        File textFile = new File(imageFile.getParentFile(), FilenameUtils.getBaseName(imageFile.getName()) + ".txt");
 
         // Now we can delegate to ShowTextFileAction with the createIfNotPresent option set to true:
-        ShowTextFileAction action = new ShowTextFileAction(testFile);
+        ShowTextFileAction action = new ShowTextFileAction(textFile);
         action.setCreateIfNotPresent(true);
         action.actionPerformed(e);
     }

--- a/src/main/java/ca/corbett/imageviewer/extensions/companiontext/actions/ShowCurrentAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/companiontext/actions/ShowCurrentAction.java
@@ -1,0 +1,42 @@
+package ca.corbett.imageviewer.extensions.companiontext.actions;
+
+import ca.corbett.extras.EnhancedAction;
+import ca.corbett.imageviewer.ui.ImageInstance;
+import ca.corbett.imageviewer.ui.MainWindow;
+import org.apache.commons.io.FilenameUtils;
+
+import java.awt.event.ActionEvent;
+import java.io.File;
+
+/**
+ * An action to launch the companion text file viewer/editor for the currently selected
+ * image. This action will create a new empty text file if none exists.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since 3.0.0
+ */
+public class ShowCurrentAction extends EnhancedAction {
+
+    public ShowCurrentAction(String name) {
+        super(name);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        ImageInstance currentImage = MainWindow.getInstance().getSelectedImage();
+        if (currentImage.isEmpty()) {
+            MainWindow.getInstance().showMessageDialog(NAME, "Nothing selected.");
+            return;
+        }
+
+        // Figure out where the companion text file should live:
+        // (it's no problem if it's not there, our ShowTextFileAction will handle that)
+        File imageFile = currentImage.getImageFile();
+        File testFile = new File(imageFile.getParentFile(), FilenameUtils.getBaseName(imageFile.getName()) + ".txt");
+
+        // Now we can delegate to ShowTextFileAction with the createIfNotPresent option set to true:
+        ShowTextFileAction action = new ShowTextFileAction(testFile);
+        action.setCreateIfNotPresent(true);
+        action.actionPerformed(e);
+    }
+}

--- a/src/main/java/ca/corbett/imageviewer/extensions/companiontext/actions/ShowTextFileAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/companiontext/actions/ShowTextFileAction.java
@@ -116,11 +116,14 @@ public class ShowTextFileAction extends EnhancedAction {
             log.warning("CompanionTextFile: No text file to show.");
             return false;
         }
-        if ((!textFile.exists() || !textFile.isFile() || !textFile.canRead()) && !createIfNotPresent) {
-            log.warning("CompanionTextFile: Invalid or unreadable text file: " + textFile.getAbsolutePath());
-            return false;
-        }
-        if (!createIfNotPresent) {
+
+        // If the file exists: it has to be readable and a valid text file:
+        if (textFile.exists()) {
+            if (!textFile.isFile() || !textFile.canRead()) {
+                log.warning("CompanionTextFile: Invalid or unreadable text file: " + textFile.getAbsolutePath());
+                return false;
+            }
+
             try {
                 if (!TextFileDetector.isTextFile(textFile)) {
                     getMessageUtil().warning("Not a text file",
@@ -137,7 +140,7 @@ public class ShowTextFileAction extends EnhancedAction {
         }
 
         // If the file doesn't exist, that may or may not be a problem:
-        if (!textFile.exists()) {
+        else {
             // If we were not explicitly told to create it, just inform the user and bail:
             if (!createIfNotPresent) {
                 getMessageUtil().info("File not found",

--- a/src/main/java/ca/corbett/imageviewer/extensions/companiontext/actions/ShowTextFileAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/companiontext/actions/ShowTextFileAction.java
@@ -73,22 +73,22 @@ public class ShowTextFileAction extends EnhancedAction {
         dialog.setReadOnly(false);
         dialog.setVisible(true);
 
-        // Save the results if the user okayed the dialog and made changes:
-        if (dialog.wasOkayed() && !text.equals(dialog.getText())) {
+        // Save the results if the user okayed the dialog:
+        if (dialog.wasOkayed()) {
             try {
                 FileSystemUtil.writeStringToFile(dialog.getText(), textFile);
+
+                // Force a refresh if this is a new file:
+                // (this will allow our hyperlink label to get added to the thumb panel)
+                // (I'd rather just surgically do that here, because we know only one thumb panel
+                //  needs updating, but there's no avenue in the parent application to get to it from here, so...)
+                if (fileWasCreated) {
+                    MainWindow.getInstance().reload();
+                }
             }
             catch (IOException ioe) {
                 getMessageUtil().error("Problem saving companion text file: " + ioe.getMessage(), "Save Error", ioe);
             }
-        }
-
-        // Force a refresh if this is a new file:
-        // (this will allow our hyperlink label to get added to the thumb panel)
-        // (I'd rather just surgically do that here, because we know only one thumb panel
-        //  needs updating, but there's no avenue in the parent application to get to it from here, so...)
-        if (dialog.wasOkayed() && fileWasCreated) {
-            MainWindow.getInstance().reload();
         }
     }
 
@@ -97,7 +97,8 @@ public class ShowTextFileAction extends EnhancedAction {
      */
     private String getFileContents() {
         try {
-            return FileSystemUtil.readFileToString(textFile);
+            // It's possible the file doesn't exist yet (if createIfNotPresent is true):
+            return textFile.exists() ? FileSystemUtil.readFileToString(textFile) : "";
         }
         catch (IOException ioe) {
             log.log(Level.SEVERE, "Error reading companion text file: " + textFile.getAbsolutePath(), ioe);
@@ -148,20 +149,14 @@ public class ShowTextFileAction extends EnhancedAction {
                 return false;
             }
 
-            // Otherwise, initialize the file with empty contents:
-            try {
-                FileSystemUtil.writeStringToFile("", textFile);
-                fileWasCreated = true; // flag this so we can force a refresh later if the dialog is okayed
-            }
-            catch (IOException ioe) {
-                getMessageUtil().error("File creation error",
-                                       "Problem creating companion text file: " + ioe.getMessage(),
-                                       ioe);
-                return false;
-            }
+            // Otherwise, just let it fall through and return true.
+            // The file will get created if/when the user okays the dialog.
+            //
+            // We will, however, note that the file is being created, so we can
+            // force a refresh later:
+            fileWasCreated = true;
         }
 
-        // If we get here, the file is either valid, or we have created it successfully:
         return true;
     }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/companiontext/actions/ShowTextFileAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/companiontext/actions/ShowTextFileAction.java
@@ -4,6 +4,7 @@ import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.MessageUtil;
 import ca.corbett.extras.PopupTextDialog;
 import ca.corbett.extras.io.FileSystemUtil;
+import ca.corbett.extras.io.TextFileDetector;
 import ca.corbett.imageviewer.ui.MainWindow;
 
 import java.awt.event.ActionEvent;
@@ -16,6 +17,8 @@ import java.util.logging.Logger;
  * An action to show/edit a companion text file associated with an image.
  * The text file to be shown/edited is specified when constructing the action,
  * but can be modified later via setTextFile() if the text file is renamed or moved.
+ * Alternatively, you can set the createIfNotPresent option (default false) to
+ * have the action create a new empty text file if it does not already exist.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since 3.0.0
@@ -25,10 +28,23 @@ public class ShowTextFileAction extends EnhancedAction {
     private static final Logger log = Logger.getLogger(ShowTextFileAction.class.getName());
     private MessageUtil messageUtil;
     private File textFile;
+    private boolean createIfNotPresent;
+    private boolean fileWasCreated;
 
     public ShowTextFileAction(File textFile) {
         super("View/Edit companion text file");
         this.textFile = textFile;
+        this.createIfNotPresent = false;
+        this.fileWasCreated = false;
+    }
+
+    public boolean isCreateIfNotPresent() {
+        return createIfNotPresent;
+    }
+
+    public ShowTextFileAction setCreateIfNotPresent(boolean createIfNotPresent) {
+        this.createIfNotPresent = createIfNotPresent;
+        return this;
     }
 
     public File getTextFile() {
@@ -38,32 +54,26 @@ public class ShowTextFileAction extends EnhancedAction {
     /**
      * If the associated image file is renamed or moved, you can call this
      * method to update the text file reference.
-     *
-     * @param textFile The new location of our text file.
      */
-    public void setTextFile(File textFile) {
+    public ShowTextFileAction setTextFile(File textFile) {
         this.textFile = textFile;
+        return this;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        if (textFile == null || !textFile.exists() || !textFile.isFile()) {
-            log.warning("CompanionTextFile: No text file to show.");
-            return;
+        fileWasCreated = false;
+        if (!validateFile()) {
+            return; // error already logged/shown
         }
 
-        String text;
+        String text = getFileContents();
         String title = "Text for " + textFile.getName();
-        try {
-            text = FileSystemUtil.readFileToString(textFile);
-        }
-        catch (IOException ioe) {
-            text = ioe.getMessage() == null ? "" : ioe.getMessage();
-            log.log(Level.SEVERE, "Error reading companion text file: " + textFile.getAbsolutePath(), ioe);
-        }
         PopupTextDialog dialog = new PopupTextDialog(MainWindow.getInstance(), title, text, true);
         dialog.setReadOnly(false);
         dialog.setVisible(true);
+
+        // Save the results if the user okayed the dialog and made changes:
         if (dialog.wasOkayed() && !text.equals(dialog.getText())) {
             try {
                 FileSystemUtil.writeStringToFile(dialog.getText(), textFile);
@@ -72,6 +82,84 @@ public class ShowTextFileAction extends EnhancedAction {
                 getMessageUtil().error("Problem saving companion text file: " + ioe.getMessage(), "Save Error", ioe);
             }
         }
+
+        // Force a refresh if this is a new file:
+        // (this will allow our hyperlink label to get added to the thumb panel)
+        // (I'd rather just surgically do that here, because we know only one thumb panel
+        //  needs updating, but there's no avenue in the parent application to get to it from here, so...)
+        if (dialog.wasOkayed() && fileWasCreated) {
+            MainWindow.getInstance().reload();
+        }
+    }
+
+    /**
+     * Retrieves the file's contents as a string.
+     */
+    private String getFileContents() {
+        try {
+            return FileSystemUtil.readFileToString(textFile);
+        }
+        catch (IOException ioe) {
+            log.log(Level.SEVERE, "Error reading companion text file: " + textFile.getAbsolutePath(), ioe);
+            return ioe.getMessage() == null ? "" : ioe.getMessage();
+        }
+    }
+
+    /**
+     * Invoked internally to check our given textFile for validity.
+     *
+     * @return true if we're good, false if some warning or error has been logged.
+     */
+    private boolean validateFile() {
+        // If we were given garbage input, just log a warning and bail:
+        if (textFile == null) {
+            log.warning("CompanionTextFile: No text file to show.");
+            return false;
+        }
+        if ((!textFile.exists() || !textFile.isFile() || !textFile.canRead()) && !createIfNotPresent) {
+            log.warning("CompanionTextFile: Invalid or unreadable text file: " + textFile.getAbsolutePath());
+            return false;
+        }
+        if (!createIfNotPresent) {
+            try {
+                if (!TextFileDetector.isTextFile(textFile)) {
+                    getMessageUtil().warning("Not a text file",
+                                             "The specified companion text file does not appear to be a text file:\n" +
+                                                 textFile.getAbsolutePath());
+                    return false;
+                }
+            }
+            catch (IOException ioe) {
+                getMessageUtil().error("File error",
+                                       "Problem checking companion text file type: " + ioe.getMessage(), ioe);
+                return false;
+            }
+        }
+
+        // If the file doesn't exist, that may or may not be a problem:
+        if (!textFile.exists()) {
+            // If we were not explicitly told to create it, just inform the user and bail:
+            if (!createIfNotPresent) {
+                getMessageUtil().info("File not found",
+                                      "No companion text file found at:\n" + textFile.getAbsolutePath());
+                return false;
+            }
+
+            // Otherwise, initialize the file with empty contents:
+            try {
+                FileSystemUtil.writeStringToFile("", textFile);
+                fileWasCreated = true; // flag this so we can force a refresh later if the dialog is okayed
+            }
+            catch (IOException ioe) {
+                getMessageUtil().error("File creation error",
+                                       "Problem creating companion text file: " + ioe.getMessage(),
+                                       ioe);
+                return false;
+            }
+        }
+
+        // If we get here, the file is either valid, or we have created it successfully:
+        return true;
     }
 
     private MessageUtil getMessageUtil() {

--- a/src/main/java/ca/corbett/imageviewer/extensions/companiontext/actions/ShowTextFileAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/companiontext/actions/ShowTextFileAction.java
@@ -87,7 +87,7 @@ public class ShowTextFileAction extends EnhancedAction {
                 }
             }
             catch (IOException ioe) {
-                getMessageUtil().error("Problem saving companion text file: " + ioe.getMessage(), "Save Error", ioe);
+                getMessageUtil().error("Save Error", "Problem saving companion text file: " + ioe.getMessage(), ioe);
             }
         }
     }


### PR DESCRIPTION
This PR addresses issue #8 by adding a way to launch the companion text file viewer/editor even if no companion text file exists for the currently selected image. A new action has been added for this purpose, with a configurable keyboard shortcut (defaults to Ctrl+T). When invoked, it will delegate to the existing `ShowTextFileAction` with an extra parameter to create the text file if it does not already exist.